### PR TITLE
Add support for multiple platforms

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,5 +45,5 @@ jobs:
           push: true
           context: .
           file: ./cmd/out_clickhouse/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm,linux/arm64
           tags: kobsio/fluent-bit-clickhouse:${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
With this commit we are now building the Docker image for all the
supported platforms of the "fluent/fluent-bit" base Docker image.