### PR TITLE
Add flush interval setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ## Unreleased
 
 - [#2](https://github.com/kobsio/fluent-bit-clickhouse/pull/2): Add changelog.
+- [#3](https://github.com/kobsio/fluent-bit-clickhouse/pull/3): Add flush interval setting, so that the buffer is flushed after the defined interval or when the buffer size is reached.
 
 ## [v0.3.0](https://github.com/kobsio/fluent-bit-clickhouse/releases/tag/v0.3.0) (2021-09-03)
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ In the following you found an example configuration for Fluent Bit:
     Add   cluster fluent-bit-clickhouse
 
 [OUTPUT]
-    Name          clickhouse
-    Match         *
-    Address       clickhouse-clickhouse.clickhouse.svc.cluster.local:9000
-    Database      logs
-    Username      admin
-    Password      admin
-    Write_Timeout 20
-    Read_Timeout  10
-    Batch_Size    10000
+    Name           clickhouse
+    Match          *
+    Address        clickhouse-clickhouse.clickhouse.svc.cluster.local:9000
+    Database       logs
+    Username       admin
+    Password       admin
+    Write_Timeout  20
+    Read_Timeout   10
+    Batch_Size     10000
+    Flush_Interval 1m
 ```
 
 The SQL schema for ClickHouse must be created on each ClickHouse node and looks as follows:

--- a/cluster/fluent-bit/fluent-bit-cm.yaml
+++ b/cluster/fluent-bit/fluent-bit-cm.yaml
@@ -47,16 +47,16 @@ data:
         Add   cluster fluent-bit-clickhouse
 
     [OUTPUT]
-        Name          clickhouse
-        Match         *
-        Address       clickhouse-clickhouse.clickhouse.svc.cluster.local:9000
-        Database      logs
-        Username      admin
-        Password      admin
-        Write_Timeout 20
-        Read_Timeout  10
-        # This is only for testing, do not use such a low value in production.
-        Batch_Size    10
+        Name           clickhouse
+        Match          *
+        Address        clickhouse-clickhouse.clickhouse.svc.cluster.local:9000
+        Database       logs
+        Username       admin
+        Password       admin
+        Write_Timeout  20
+        Read_Timeout   10
+        Batch_Size     10000
+        Flush_Interval 1m
 
   parsers.conf: |
     [PARSER]

--- a/conf/fluent-bit.conf
+++ b/conf/fluent-bit.conf
@@ -14,12 +14,13 @@
     Interval_Sec 1
 
 [OUTPUT]
-    Name          clickhouse
-    Match         *
-    Address       127.0.0.1:9000
-    Database      logs
-    Username      admin
-    Password      admin
-    Write_Timeout 20
-    Read_Timeout  10
-    Batch_Size    10000
+    Name           clickhouse
+    Match          *
+    Address        127.0.0.1:9000
+    Database       logs
+    Username       admin
+    Password       admin
+    Write_Timeout  20
+    Read_Timeout   10
+    Batch_Size     10000
+    Flush_Interval 1m


### PR DESCRIPTION
This commit introduces a new setting to define the flush interval. The
setting can be specified via the "flush_interval" property in the
config. With this new setting the entries from the buffer will now be
written to ClickHouse after the defined flush interval or when the
buffer is larger then the defined batch size setting.