### PR TITLE
Add GitHub Action to run tests and build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Cache Go
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download Dependencies
+        run: |
+          go mod download
+
+      - name: Test
+        run: |
+          go test ./...
+
+      - name: Build Fluent Bit ClickHouse
+        run: |
+          make build-fluent-bit-clickhouse
+
+      - name: Build Fluent Bit Kafka ClickHouse
+        run: |
+          make build-fluent-bit-kafka-clickhouse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#11](https://github.com/kobsio/fluent-bit-clickhouse/pull/11): Update Fluent Bit to version 1.8.9.
 - [#12](https://github.com/kobsio/fluent-bit-clickhouse/pull/12): Add support for [async inserts](https://clickhouse.com/blog/en/2021/clickhouse-v21.11-released/#async-inserts).
+- [#13](https://github.com/kobsio/fluent-bit-clickhouse/pull/13): Add GitHub Action to run tests and build on every push.
 
 ## [v0.5.2](https://github.com/kobsio/fluent-bit-clickhouse/releases/tag/v0.5.2) (2021-10-21)
 


### PR DESCRIPTION
This commit adds a new GitHub Action to run our tests and the build for
each binary on every push.